### PR TITLE
feature/update batch data sync models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.9"
 
 dependencies = [
     "boto3~=1.26.49",
-    "aibs-informatics-core @ git+ssh://git@github.com/AllenInstitute/aibs-informatics-core.git@feature/update-batch-data-sync-models",
+    "aibs-informatics-core @ git+ssh://git@github.com/AllenInstitute/aibs-informatics-core.git@main",
 ]
 
 [project.optional-dependencies]

--- a/src/aibs_informatics_aws_utils/efs/mount_point.py
+++ b/src/aibs_informatics_aws_utils/efs/mount_point.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from functools import cache
 
 __all__ = [
     "MountPointConfiguration",
@@ -375,6 +376,7 @@ class MountPointConfiguration:
         )
 
 
+@cache
 def detect_mount_points() -> List[MountPointConfiguration]:
     mount_points: List[MountPointConfiguration] = []
 

--- a/test/aibs_informatics_aws_utils/data_sync/test_file_system.py
+++ b/test/aibs_informatics_aws_utils/data_sync/test_file_system.py
@@ -27,6 +27,7 @@ from aibs_informatics_aws_utils.data_sync.file_system import (
     S3FileSystem,
 )
 from aibs_informatics_aws_utils.efs import MountPointConfiguration
+from aibs_informatics_aws_utils.efs.mount_point import detect_mount_points
 
 
 def any_s3_uri(bucket: str = "bucket", key: str = "key") -> S3URI:
@@ -282,6 +283,10 @@ class LocalFileSystemTests(BaseTest):
 
 @mock_sts
 class EFSFileSystemTests(EFSTestsBase):
+    def setUp(self) -> None:
+        super().setUp()
+        detect_mount_points.cache_clear()
+
     def setUpEFSFileSystem(
         self, name: str, access_point_path: Optional[Union[str, Path]] = None
     ) -> Tuple[Path, EFSPath]:

--- a/test/aibs_informatics_aws_utils/efs/test_mount_point.py
+++ b/test/aibs_informatics_aws_utils/efs/test_mount_point.py
@@ -21,6 +21,10 @@ from aibs_informatics_aws_utils.efs import (
 
 @mock_sts
 class MountPointConfigurationTests(EFSTestsBase):
+    def setUp(self) -> None:
+        super().setUp()
+        detect_mount_points.cache_clear()
+
     def setUpEFS(self, *access_points: Tuple[str, Path], file_system_name: Optional[str] = None):
         self.create_file_system(file_system_name)
         for access_point_name, access_point_path in access_points:


### PR DESCRIPTION
- tmp
- add cache to detect_mount_points

## What's in this Change?

I am adding cache for detecting mount points

**Why?** - because we are being hit with throttling errors from describing efs file systems, it is effectively static once invoked in a system, and it is a costly call if invoked many times over. 


## Testing

* changes made to unit tests
