### PR TITLE
OCSDV-343: Resolve lingering part files when S3 -> EFS transfers fail

### DIFF
--- a/test/aibs_informatics_aws_utils/data_sync/test_operations.py
+++ b/test/aibs_informatics_aws_utils/data_sync/test_operations.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 import moto
 from aibs_informatics_core.models.aws.s3 import S3URI
+from aibs_informatics_core.models.data_sync import RemoteToLocalConfig
 from aibs_informatics_core.utils.os_operations import find_all_paths
 
 from aibs_informatics_aws_utils.data_sync.operations import sync_data
@@ -267,6 +268,33 @@ class OperationsTests(AwsBaseTest):
             source_path=source_path, destination_path=destination_path, fail_if_missing=False
         )
         assert not destination_path.exists()
+
+    def test__sync_data__s3_to_local__file__auto_custom_tmp_dir__succeeds(self):
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        source_path = self.put_object("source", "hello")
+        destination_path = fs / "destination"
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            remote_to_local_config=RemoteToLocalConfig(use_custom_tmp_dir=True),
+        )
+        self.assertPathsEqual(source_path, destination_path, 1)
+
+    def test__sync_data__s3_to_local__file__specified_custom_tmp_dir__succeeds(self):
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        source_path = self.put_object("source", "hello")
+        destination_path = fs / "destination"
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            remote_to_local_config=RemoteToLocalConfig(
+                use_custom_tmp_dir=True,
+                custom_tmp_dir=fs,
+            ),
+        )
+        self.assertPathsEqual(source_path, destination_path, 1)
 
     def test__sync_data__local_to_s3__folder__succeeds(self):
         fs = self.setUpLocalFS()


### PR DESCRIPTION
This commit changes the behavior of the `DataSyncOperations.sync_s3_to_local()`
method so that when it is downloading from a discrete
s3 object -> local filesystem (usually EFS), it will download the
s3 object to a custom temporary location on the same file system
as the destination and then `os.rename` to the final destination path.

When Boto3 downloads an s3 object, it will create a temporary version
of the file in the SAME parent directory as the destination path
(e.g. "/file_system/dst/path/input_data.fastq.gz" will result in
a temporary file at
"/file_system/dst/path/input_data.fastq.gz.{unique_hash}")

This default behavior by Boto3 is normally okay, but becomes problematic
when two specific things happen:

1. A data sync is interrupted in a way that Boto3 doesn't have time to
   clean up the temporary file

   - Subsequent runs of data sync also can't clean up the file because
     our data sync logic only knows about syncing the single object and
     has no knowledge about the lingering temporary file (from a
     previous sync attempt)

2. A scientific executable that we need to support (e.g. cellranger)
   is excessively greedy when looking for putative FASTQ input files and
   will even grab partial files with names like `*.fastq.gz.6eF5b5da`.

By saving the partial files during the Boto3 object download process in a
different location and only atomically moving files which have completed
transfer we can avoid this situation.