### PR TITLE
Update optional dependency for aibs-informatics-test-resources to include all extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "aibs-informatics-test-resources",
+    "aibs-informatics-test-resources[all]",
     "boto3-stubs[athena,apigateway,batch,ecr,ecs,efs,essential,fsx,logs,secretsmanager,ses,sns,ssm,sts,stepfunctions]",
     "moto[all] ~= 5.0",
 ]


### PR DESCRIPTION
the test resources dependency is related to upcoming changes to https://github.com/AllenInstitute/aibs-informatics-test-resources/pull/5