### PR TITLE
Slightly relax aibs-informatics-core pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.9"
 
 dependencies = [
     "boto3~=1.35",
-    "aibs-informatics-core~=0.1.0",
+    "aibs-informatics-core~=0.1",
 ]
 
 # For dev dependencies: https://peps.python.org/pep-0735/


### PR DESCRIPTION
Previous pinning of `aibs-informatics-core` in this package pinned the allowable version to patches of `0.1` (e.g. `0.1.*`).

This commit slightly relaxes the pinning to allow minor versions like `0.2` (e.g. `0.*.*`)