### PR TITLE
bugfix/add image digest back to ecr image model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ install-release: .uv  ## Installs package dependencies
 	uv sync --frozen --group release
 
 
-rebuild-lockfile: .uv  ## Rebuilds the lockfile
+upgrade-lockfile: .uv  ## Upgrade lockfile to latest compatible versions (uv lock --upgrade)
 	uv lock --upgrade
 
 link-packages: ## Link local packages to virtualenv  
@@ -107,7 +107,7 @@ unlink-packages: ## Unlink local packages from virtualenv
 		make install; \
 	fi
 
-.PHONY: .uv install install-release install rebuild-lockfile link-packages unlink-packages
+.PHONY: .uv install install-release upgrade-lockfile link-packages unlink-packages
 
 #######################
 ##@ Formatting Commands

--- a/src/aibs_informatics_aws_utils/ecr/core.py
+++ b/src/aibs_informatics_aws_utils/ecr/core.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Self,
     TypedDict,
     TypeVar,
     cast,
@@ -18,7 +19,11 @@ import requests
 from aibs_informatics_core.collections import StrEnum, ValidatedStr
 from aibs_informatics_core.models.base import PydanticBaseModel
 from botocore.exceptions import ClientError
-from pydantic import Field, PrivateAttr, model_validator
+from pydantic import (
+    Field,
+    PrivateAttr,
+    model_validator,
+)
 
 from aibs_informatics_aws_utils.core import (
     AWSService,
@@ -312,12 +317,23 @@ T = TypeVar("T", bound="ECRResourceBase")
 
 
 class ECRResourceBase(PydanticBaseModel):
-    _client: ECRClient | None = PrivateAttr(default=None)
+    client: ECRClient = Field(default=None, exclude=True)  # type: ignore
+    # _client: ECRClient | None = PrivateAttr(default=None)
     _logger: logging.Logger | None = PrivateAttr(default=None)
 
-    def __init__(self, *, client: ECRClient | None = None, **data) -> None:
-        super().__init__(**data)
-        self._client = client
+    # def __init__(self, *, client: ECRClient | None = None, **data) -> None:
+    #     super().__init__(**data)
+    #     self._client = client
+
+    # @property
+    # def client(self) -> ECRClient:
+    #     if self._client is None:
+    #         self._client = get_ecr_client(getattr(self, "region"))
+    #     return self._client
+
+    # @client.setter
+    # def client(self, value: ECRClient):
+    #     self._client = value
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
@@ -327,21 +343,22 @@ class ECRResourceBase(PydanticBaseModel):
     def __hash__(self) -> int:
         return hash(tuple(sorted(self.model_dump().items())))
 
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_client(cls, data: Any) -> Any:
+        if "client" in data and data["client"] is not None:
+            if not isinstance(data["client"], ECRClient):
+                raise TypeError(f"client must be of type ECRClient, got {type(data['client'])}")
+        elif data.get("client") is None:
+            data["client"] = get_ecr_client(region=data.get("region"))
+        return data
+
+
     @property
     def logger(self) -> logging.Logger:
         if self._logger is None:
             self._logger = logging.getLogger(f"{__name__}.{type(self).__name__}")
         return self._logger
-
-    @property
-    def client(self) -> ECRClient:
-        if self._client is None:
-            self._client = get_ecr_client(getattr(self, "region"))
-        return self._client
-
-    @client.setter
-    def client(self, value: ECRClient):
-        self._client = value
 
     @property
     def uri(self) -> str:
@@ -358,26 +375,24 @@ class ECRImage(ECRResourceBase):
     repository_name: str
     image_digest: str
     # https://distribution.github.io/distribution/spec/manifest-v2-2/#image-manifest-field-descriptions
-    _image_manifest: str | None = PrivateAttr(default=None)
+    image_manifest: str = Field(default=None)  # type: ignore[assignment]
 
-    def __init__(self, *, image_manifest: str | None = None, **data):
-        super().__init__(**data)
-        self._image_manifest = image_manifest
-        self.image_manifest  # trigger validation of manifest if provided
+    @model_validator(mode="after")
+    def model_validator_validate_image_manifest(self) -> Self:
+        if self.image_manifest is None:
+            self.image_manifest = self.fetch_image_manifest()
+        return self
 
-    @property
-    def image_manifest(self) -> str:
-        if self._image_manifest is None:
-            response = self.client.batch_get_image(
-                repositoryName=self.repository_name,
-                registryId=self.account_id,
-                imageIds=[ImageIdentifierTypeDef(imageDigest=self.image_digest)],
-            )
-            if len(response["images"]) == 0 or "imageManifest" not in response["images"][0]:
-                raise ResourceNotFoundError(f"Could not resolve image manifest for {self.uri}")
+    def fetch_image_manifest(self) -> str:
+        response = self.client.batch_get_image(
+            repositoryName=self.repository_name,
+            registryId=self.account_id,
+            imageIds=[ImageIdentifierTypeDef(imageDigest=self.image_digest)],
+        )
+        if len(response["images"]) == 0 or "imageManifest" not in response["images"][0]:
+            raise ResourceNotFoundError(f"Could not resolve image manifest for {self.uri}")
 
-            self._image_manifest = response["images"][0]["imageManifest"]
-        return self._image_manifest
+        return response["images"][0]["imageManifest"]
 
     @property
     def image_pushed_at(self) -> datetime | None:

--- a/src/aibs_informatics_aws_utils/ecr/core.py
+++ b/src/aibs_informatics_aws_utils/ecr/core.py
@@ -317,6 +317,7 @@ T = TypeVar("T", bound="ECRResourceBase")
 
 
 class ECRResourceBase(PydanticBaseModel):
+    _client: ECRClient | None = PrivateAttr(default=None)
     _logger: logging.Logger | None = PrivateAttr(default=None)
 
     def __init__(self, client: ECRClient | None = None, **data: Any) -> None:
@@ -330,13 +331,6 @@ class ECRResourceBase(PydanticBaseModel):
 
     def __hash__(self) -> int:
         return hash(tuple(sorted(self.model_dump().items())))
-
-    @model_validator(mode="before")
-    @classmethod
-    def _validate_client(cls, data: Any) -> Any:
-        if data.get("client") is None:
-            data["client"] = get_ecr_client(region=data.get("region"))
-        return data
 
     @property
     def client(self) -> ECRClient:
@@ -378,10 +372,10 @@ class ECRImage(ECRResourceBase):
         client: ECRClient | None = None,
     ) -> None:
         super().__init__(  # type: ignore[call-arg]
-            account_id=account_id, # pyright: ignore[reportCallIssue]
-            region=region, # pyright: ignore[reportCallIssue]
-            repository_name=repository_name, # pyright: ignore[reportCallIssue]
-            image_digest=image_digest, # pyright: ignore[reportCallIssue]
+            account_id=account_id,  # pyright: ignore[reportCallIssue]
+            region=region,  # pyright: ignore[reportCallIssue]
+            repository_name=repository_name,  # pyright: ignore[reportCallIssue]
+            image_digest=image_digest,  # pyright: ignore[reportCallIssue]
             client=client,  # type: ignore[arg-type]
         )
         self._image_manifest = image_manifest

--- a/src/aibs_informatics_aws_utils/ecr/core.py
+++ b/src/aibs_informatics_aws_utils/ecr/core.py
@@ -9,7 +9,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Self,
     TypedDict,
     TypeVar,
     cast,
@@ -22,6 +21,7 @@ from botocore.exceptions import ClientError
 from pydantic import (
     Field,
     PrivateAttr,
+    model_serializer,
     model_validator,
 )
 
@@ -317,23 +317,8 @@ T = TypeVar("T", bound="ECRResourceBase")
 
 
 class ECRResourceBase(PydanticBaseModel):
-    client: ECRClient = Field(default=None, exclude=True)  # type: ignore
-    # _client: ECRClient | None = PrivateAttr(default=None)
+    client: "ECRClient | None" = Field(default=None, exclude=True)
     _logger: logging.Logger | None = PrivateAttr(default=None)
-
-    # def __init__(self, *, client: ECRClient | None = None, **data) -> None:
-    #     super().__init__(**data)
-    #     self._client = client
-
-    # @property
-    # def client(self) -> ECRClient:
-    #     if self._client is None:
-    #         self._client = get_ecr_client(getattr(self, "region"))
-    #     return self._client
-
-    # @client.setter
-    # def client(self, value: ECRClient):
-    #     self._client = value
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
@@ -346,13 +331,9 @@ class ECRResourceBase(PydanticBaseModel):
     @model_validator(mode="before")
     @classmethod
     def _validate_client(cls, data: Any) -> Any:
-        if "client" in data and data["client"] is not None:
-            if not isinstance(data["client"], ECRClient):
-                raise TypeError(f"client must be of type ECRClient, got {type(data['client'])}")
-        elif data.get("client") is None:
+        if data.get("client") is None:
             data["client"] = get_ecr_client(region=data.get("region"))
         return data
-
 
     @property
     def logger(self) -> logging.Logger:
@@ -375,13 +356,36 @@ class ECRImage(ECRResourceBase):
     repository_name: str
     image_digest: str
     # https://distribution.github.io/distribution/spec/manifest-v2-2/#image-manifest-field-descriptions
-    image_manifest: str = Field(default=None)  # type: ignore[assignment]
+    _image_manifest: str | None = PrivateAttr(default=None)
 
-    @model_validator(mode="after")
-    def model_validator_validate_image_manifest(self) -> Self:
-        if self.image_manifest is None:
-            self.image_manifest = self.fetch_image_manifest()
-        return self
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        region: str,
+        repository_name: str,
+        image_digest: str,
+        image_manifest: str | None = None,
+        client: ECRClient | None = None,
+    ) -> None:
+        super().__init__(
+            account_id=account_id,
+            region=region,
+            repository_name=repository_name,
+            image_digest=image_digest,
+            client=client,
+        )
+        self._image_manifest = image_manifest
+
+    @property
+    def image_manifest(self) -> str:
+        if self._image_manifest is None:
+            self._image_manifest = self.fetch_image_manifest()
+        return self._image_manifest
+
+    @image_manifest.setter
+    def image_manifest(self, value: str) -> None:
+        self._image_manifest = value
 
     def fetch_image_manifest(self) -> str:
         response = self.client.batch_get_image(
@@ -586,6 +590,38 @@ class ECRImage(ECRResourceBase):
             repository_name=repo_name,
             image_digest=image_digest,
         )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (
+            self.account_id == other.account_id
+            and self.region == other.region
+            and self.repository_name == other.repository_name
+            and self.image_digest == other.image_digest
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.account_id, self.region, self.repository_name, self.image_digest))
+
+    @model_serializer(mode="wrap")
+    def _serialize_with_manifest(self, handler) -> dict[str, Any]:
+        d = handler(self)
+        if self._image_manifest is not None:
+            d["image_manifest"] = self._image_manifest
+        return d
+
+    @classmethod
+    def from_dict(cls, data, **kwargs) -> "ECRImage":
+        if isinstance(data, dict):
+            data = dict(data)  # avoid mutating the input
+            image_manifest = data.pop("image_manifest", None)
+        else:
+            image_manifest = None
+        instance = super().from_dict(data, **kwargs)
+        if image_manifest is not None:
+            instance._image_manifest = image_manifest
+        return instance
 
     def __repr__(self) -> str:
         return (

--- a/src/aibs_informatics_aws_utils/ecr/core.py
+++ b/src/aibs_informatics_aws_utils/ecr/core.py
@@ -317,8 +317,11 @@ T = TypeVar("T", bound="ECRResourceBase")
 
 
 class ECRResourceBase(PydanticBaseModel):
-    client: "ECRClient | None" = Field(default=None, exclude=True)
     _logger: logging.Logger | None = PrivateAttr(default=None)
+
+    def __init__(self, client: ECRClient | None = None, **data: Any) -> None:
+        super().__init__(**data)
+        self._client = client
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, type(self)):
@@ -334,6 +337,12 @@ class ECRResourceBase(PydanticBaseModel):
         if data.get("client") is None:
             data["client"] = get_ecr_client(region=data.get("region"))
         return data
+
+    @property
+    def client(self) -> ECRClient:
+        if self._client is None:
+            self._client = get_ecr_client(region=getattr(self, "region", None))
+        return cast(ECRClient, self._client)
 
     @property
     def logger(self) -> logging.Logger:
@@ -368,14 +377,21 @@ class ECRImage(ECRResourceBase):
         image_manifest: str | None = None,
         client: ECRClient | None = None,
     ) -> None:
-        super().__init__(
-            account_id=account_id,
-            region=region,
-            repository_name=repository_name,
-            image_digest=image_digest,
-            client=client,
+        super().__init__(  # type: ignore[call-arg]
+            account_id=account_id, # pyright: ignore[reportCallIssue]
+            region=region, # pyright: ignore[reportCallIssue]
+            repository_name=repository_name, # pyright: ignore[reportCallIssue]
+            image_digest=image_digest, # pyright: ignore[reportCallIssue]
+            client=client,  # type: ignore[arg-type]
         )
         self._image_manifest = image_manifest
+
+    @model_serializer(mode="wrap")
+    def _serialize_with_manifest(self, handler) -> dict[str, Any]:
+        d = handler(self)
+        if self._image_manifest is not None:
+            d["image_manifest"] = self._image_manifest
+        return d
 
     @property
     def image_manifest(self) -> str:
@@ -603,25 +619,6 @@ class ECRImage(ECRResourceBase):
 
     def __hash__(self) -> int:
         return hash((self.account_id, self.region, self.repository_name, self.image_digest))
-
-    @model_serializer(mode="wrap")
-    def _serialize_with_manifest(self, handler) -> dict[str, Any]:
-        d = handler(self)
-        if self._image_manifest is not None:
-            d["image_manifest"] = self._image_manifest
-        return d
-
-    @classmethod
-    def from_dict(cls, data, **kwargs) -> "ECRImage":
-        if isinstance(data, dict):
-            data = dict(data)  # avoid mutating the input
-            image_manifest = data.pop("image_manifest", None)
-        else:
-            image_manifest = None
-        instance = super().from_dict(data, **kwargs)
-        if image_manifest is not None:
-            instance._image_manifest = image_manifest
-        return instance
 
     def __repr__(self) -> str:
         return (

--- a/src/aibs_informatics_aws_utils/exceptions.py
+++ b/src/aibs_informatics_aws_utils/exceptions.py
@@ -36,7 +36,7 @@ class EmptyQueryResultException(DBQueryResultException):
 # --------------------------------------------------------------------------
 
 
-class AWSError(ValueError):
+class AWSError(Exception):
     """AWS related Exception"""
 
 

--- a/src/aibs_informatics_aws_utils/exceptions.py
+++ b/src/aibs_informatics_aws_utils/exceptions.py
@@ -36,7 +36,7 @@ class EmptyQueryResultException(DBQueryResultException):
 # --------------------------------------------------------------------------
 
 
-class AWSError(Exception):
+class AWSError(ValueError):
     """AWS related Exception"""
 
 

--- a/test/aibs_informatics_aws_utils/ecr/base.py
+++ b/test/aibs_informatics_aws_utils/ecr/base.py
@@ -60,9 +60,9 @@ class ECRTestBase(AwsBaseTest):
 
     def construct_image_manifest(
         self,
-        layer_sizes: list[int] = None,
+        layer_sizes: list[int] | None = None,
         config_size: int = 123,
-        config_digest: str = None,
+        config_digest: str | None = None,
     ) -> str:
         return json.dumps(
             {
@@ -88,7 +88,7 @@ class ECRTestBase(AwsBaseTest):
         self,
         repository_name: str,
         image_id: ImageIdentifierTypeDef,
-        image_manifest: str | dict = None,
+        image_manifest: str | dict | None = None,
     ) -> ImageTypeDef:
         if image_manifest is None:
             image_manifest = self.construct_image_manifest([123])
@@ -105,7 +105,7 @@ class ECRTestBase(AwsBaseTest):
         )
 
     def construct_image_identifier(
-        self, image_digest: str = None, image_tag: str = None
+        self, image_digest: str | None = None, image_tag: str | None = None
     ) -> ImageIdentifierTypeDef:
         return ImageIdentifierTypeDef(
             remove_null_values(dict(imageDigest=image_digest, imageTag=image_tag))

--- a/test/aibs_informatics_aws_utils/ecr/test_core.py
+++ b/test/aibs_informatics_aws_utils/ecr/test_core.py
@@ -694,6 +694,51 @@ class ECRImageTests(ECRTestBase):
         actual = ECRImage.from_dict(image_dict)
         self.assertEqual(actual, image)
 
+    def test__to_dict__with_image_manifest_included(self):
+        repo = self.create_repository("repository_name")
+        image = self.put_image(repo.repository_name, image_tag="latest")
+
+        expected_dict = {
+            "account_id": self.ACCOUNT_ID,
+            "region": self.REGION,
+            "repository_name": repo.repository_name,
+            "image_digest": image.image_digest,
+            "image_manifest": image.image_manifest,
+        }
+
+        actual_dict = image.to_dict()
+        self.assertEqual(actual_dict, expected_dict)
+
+    def test__to_dict__with_image_manifest_fetched(self):
+        repo = self.create_repository("repository_name")
+        image = self.put_image(repo.repository_name, image_tag="latest")
+        reconstructed_image = ECRImage(
+            account_id=self.ACCOUNT_ID,
+            region=self.REGION,
+            repository_name=image.repository_name,
+            image_digest=image.image_digest,
+            client=self.ecr,
+        )
+
+        expected_dict = {
+            "account_id": self.ACCOUNT_ID,
+            "region": self.REGION,
+            "repository_name": repo.repository_name,
+            "image_digest": image.image_digest,
+            "image_manifest": image.image_manifest,
+        }
+
+        actual_dict = reconstructed_image.to_dict()
+        self.assertEqual(actual_dict, expected_dict)
+
+    def test__from_dict_to_dict__round_trip(self):
+        repo = self.create_repository("repository_name")
+        image = self.put_image(repo.repository_name, image_tag="latest")
+
+        image_dict = image.to_dict()
+        reconstructed_image = ECRImage.from_dict(image_dict)
+        self.assertEqual(reconstructed_image, image)
+
 
 @moto.mock_aws
 class ECRRegistryTests(ECRTestBase):

--- a/test/aibs_informatics_aws_utils/ecr/test_core.py
+++ b/test/aibs_informatics_aws_utils/ecr/test_core.py
@@ -569,13 +569,14 @@ class ECRImageTests(ECRTestBase):
 
     def test__init__without_manifest__fails_to_resolve_image_details_from_ecr(self):
         repo = self.create_repository("repository_name")
+        ecr_image = ECRImage(
+            account_id=self.ACCOUNT_ID,
+            region=self.US_WEST_2,
+            repository_name=repo.repository_name,
+            image_digest=self.construct_image_digest("1234"),
+        )
         with self.assertRaises(ResourceNotFoundError):
-            ECRImage(
-                account_id=self.ACCOUNT_ID,
-                region=self.US_WEST_2,
-                repository_name=repo.repository_name,
-                image_digest=self.construct_image_digest("1234"),
-            )
+            _ = ecr_image.image_manifest
 
     def test__from_uri__with_image_digest_succeeds(self):
         repo = self.create_repository("repository_name")
@@ -720,12 +721,36 @@ class ECRImageTests(ECRTestBase):
             client=self.ecr,
         )
 
+        # Trigger lazy fetch of manifest
+        _ = reconstructed_image.image_manifest
+
         expected_dict = {
             "account_id": self.ACCOUNT_ID,
             "region": self.REGION,
             "repository_name": repo.repository_name,
             "image_digest": image.image_digest,
             "image_manifest": image.image_manifest,
+        }
+
+        actual_dict = reconstructed_image.to_dict()
+        self.assertEqual(actual_dict, expected_dict)
+
+    def test__to_dict__without_image_manifest_fetched(self):
+        repo = self.create_repository("repository_name")
+        image = self.put_image(repo.repository_name, image_tag="latest")
+        reconstructed_image = ECRImage(
+            account_id=self.ACCOUNT_ID,
+            region=self.REGION,
+            repository_name=image.repository_name,
+            image_digest=image.image_digest,
+            client=self.ecr,
+        )
+
+        expected_dict = {
+            "account_id": self.ACCOUNT_ID,
+            "region": self.REGION,
+            "repository_name": repo.repository_name,
+            "image_digest": image.image_digest,
         }
 
         actual_dict = reconstructed_image.to_dict()

--- a/test/aibs_informatics_aws_utils/ecr/test_image_replicator.py
+++ b/test/aibs_informatics_aws_utils/ecr/test_image_replicator.py
@@ -62,15 +62,6 @@ class ECRImageReplicatorTestsStubbing(AwsBaseTest):
         }
         stubber.add_response("put_image", {}, expected_params3)
 
-        # Stub the batch_get_image call invoked in the destination ECRImage constructor
-        expected_params_batch_get = {
-            "repositoryName": "destination-repo",
-            "registryId": "222222222222",
-            "imageIds": [{"imageDigest": "sha256:" + "1234" * 16}],
-        }
-        response_batch_get = {"images": [{"imageManifest": manifest}]}
-        stubber.add_response("batch_get_image", response_batch_get, expected_params_batch_get)
-
         stubber.activate()
 
         # Create dummy source image and destination repository with client passed in at init

--- a/test/aibs_informatics_aws_utils/test_s3.py
+++ b/test/aibs_informatics_aws_utils/test_s3.py
@@ -521,7 +521,7 @@ class S3Tests(AwsBaseTest):
         download_s3_path(s3_empty_prefix, local_path / "empty_prefix")
         download_s3_path(s3_not_empty, local_path / "not_empty")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AWSError):
             download_s3_path(s3_not_empty_prefix, local_path / "not_empty_prefix")
 
     def test__download_s3_path__handles_nested_trailing_slash_objects(self):
@@ -536,7 +536,7 @@ class S3Tests(AwsBaseTest):
         local_path = self.tmp_path()
         download_s3_path(s3_empty_prefix, local_path / "empty_prefix")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AWSError):
             download_s3_path(s3_not_empty_prefix, local_path / "not_empty_prefix")
 
     def test__copy_s3_object__handles_same_path(self):

--- a/test/aibs_informatics_aws_utils/test_sns.py
+++ b/test/aibs_informatics_aws_utils/test_sns.py
@@ -35,7 +35,7 @@ class SNSTests(AwsBaseTest):
             )
 
     def test__publish__fails_if_no_target_specified(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AWSError):
             publish(
                 topic_arn=None,
                 message="test_message",


### PR DESCRIPTION
- **Rename rebuild-lockfile to upgrade-lockfile for clarity and update Makefile phony targets**
- **Add image digest and manifest handling to ECRImage model and tests**

## What's in this Change?

This PR updates the ECR models/utilities to better support serializing/deserializing `ECRImage` objects with their digest + manifest and renames a Makefile lockfile target for clarity.

**Changes:**
- Add `image_manifest` as a first-class field on `ECRImage`, including fetching/round-tripping behavior and new tests.
- Rename Makefile target `rebuild-lockfile` → `upgrade-lockfile` and update `.PHONY`.


## Testing

<!-- Add any automated/manual test steps that you have run to confirm the changes -->

