### PR TITLE
Fix `batch_get_image` pagination issue in ECRRepository.get_images()

### DIFF
--- a/src/aibs_informatics_aws_utils/ecr/core.py
+++ b/src/aibs_informatics_aws_utils/ecr/core.py
@@ -817,11 +817,19 @@ class ECRRepository(ECRResource):
             return []
 
         # Call 2: batch_get_image
-        response: BatchGetImageResponseTypeDef = self.client.batch_get_image(
-            repositoryName=self.repository_name,
-            registryId=self.account_id,
-            imageIds=[ImageIdentifierTypeDef(imageDigest=digest) for digest in image_digests],
-        )
+        # BatchGetImage supports only up to 100 imageIds per request, so paginate in chunks.
+        # We can't use the `client.get_paginator` because
+        # self.client.can_paginate("batch_get_image") returns False
+        response: dict[str, list] = {"images": [], "failures": []}
+        for start in range(0, len(image_digests), 100):
+            image_id_chunk = image_digests[start : start + 100]
+            chunk_response: BatchGetImageResponseTypeDef = self.client.batch_get_image(
+                repositoryName=self.repository_name,
+                registryId=self.account_id,
+                imageIds=[ImageIdentifierTypeDef(imageDigest=digest) for digest in image_id_chunk],
+            )
+            response["images"].extend(chunk_response.get("images", []))
+            response["failures"].extend(chunk_response.get("failures", []))
 
         # Next we consolidate the results, ensuring that the image manifests
         # are all the same. If an image digest has differing manifests,

--- a/test/aibs_informatics_aws_utils/ecr/test_core.py
+++ b/test/aibs_informatics_aws_utils/ecr/test_core.py
@@ -991,6 +991,34 @@ class ECRRepositoryTests(ECRTestBase):
         images = repo.get_images()
         self.assertListEqual(images, [image2, image1])
 
+    def test__get_images__paginates_batch_get_image_requests(self):
+        repo = self.create_repository("batch_get_image_test_repo")
+        images = [
+            self.put_image(repo.repository_name, image_tag=f"v{i}", seed=1000 + i)
+            for i in range(101)
+        ]
+
+        real_batch_get_image = repo.client.batch_get_image
+        batch_get_calls: list[list[dict]] = []
+
+        def batch_get_image_side_effect(**kwargs):
+            batch_get_calls.append(kwargs["imageIds"])
+            self.assertLessEqual(len(kwargs["imageIds"]), 100)
+            return real_batch_get_image(**kwargs)
+
+        with mock.patch.object(
+            repo.client, "batch_get_image", side_effect=batch_get_image_side_effect
+        ):
+            fetched_images = repo.get_images()
+
+        self.assertEqual(len(fetched_images), 101)
+        self.assertEqual(
+            {image.image_digest for image in fetched_images},
+            {image.image_digest for image in images},
+        )
+        self.assertEqual(len(batch_get_calls), 2)
+        self.assertTrue(all(len(chunk) <= 100 for chunk in batch_get_calls))
+
     def test__get_image__returns_image_from_digest(self):
         repo = self.create_repository("repository_name")
         image = self.put_image(repo.repository_name, image_tag="latest")


### PR DESCRIPTION
BI Core reported the following error when trying to list OCS assets:

```
response: BatchGetImageResponseTypeDef = self.client.batch_get_image(
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/var/task/botocore/client.py\", line 569, in _api_call
return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File \"/var/task/botocore/client.py\", line 1023, in _make_api_call
    raiseerror_class(parsed_response, operation_name)
botocore.errorfactory.InvalidParameterException: An error occurred
(InvalidParameterException) when calling the BatchGetImage operation:
Invalid parameter at 'imageIds'failed to satisfy constraint:
'Member must have length less than or equal to 100'"
```

This commit bugfixes the problem by paginating the request so that only 100 `imageIds` at a time can be queried. Note that there is no boto3 `client.get_paginator` support for `batch_get_image` so we must manually implement the pagination.