### PR TITLE
OCSDV-452: honor include/exclude filters in the data sync layer (PR-C)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ requires-python = ">=3.11"
 
 dependencies = [
     "boto3~=1.35",
+    # TODO(OCSDV-452): raise this floor to the R1 release of aibs-informatics-core
+    # (the release carrying DataSyncFilterConfig + utils.filters) and drop the
+    # [tool.uv.sources] override below. The current bound would happily resolve an
+    # older core lacking DataSyncFilterConfig and fail at import time inside a Batch job.
     "aibs-informatics-core>=1.0.1,<2",
     "tenacity~=9.0",
 ]
@@ -83,6 +87,21 @@ Repository = "https://github.com/AllenInstitute/aibs-informatics-aws-utils/"
 
 [tool.uv]
 default-groups = ["dev", "lint", "docs"]
+
+# TEMPORARY -- REMOVE BEFORE MERGE (OCSDV-452)
+# ---------------------------------------------------------------------------
+# This repo's changes depend on aibs-informatics-core R1 (PR-A: DataSyncFilterConfig,
+# DataSyncTask.filter_config/filter_root, DataSyncConfig.delete, and
+# aibs_informatics_core.utils.filters), which is not published yet. Until it is,
+# resolve core from the branch the R1 work lives on so CI can run.
+#
+# `tool.uv.sources` is uv-only metadata: setuptools ignores it, so the published
+# wheel still carries the plain `aibs-informatics-core>=...,<2` requirement above.
+#
+# Once R1 publishes: delete this block, raise the floor above to the R1 version,
+# and re-run `uv lock`.
+[tool.uv.sources]
+aibs-informatics-core = { git = "https://github.com/AllenInstitute/aibs-informatics-core.git", branch = "feature/OCSDV-453-demand-execution-filters" }
 
 # -----------------------------------------------------------------------------
 ##  Pyright Configurations

--- a/src/aibs_informatics_aws_utils/data_sync/file_system.py
+++ b/src/aibs_informatics_aws_utils/data_sync/file_system.py
@@ -14,6 +14,8 @@ import pytz
 from aibs_informatics_core.models.aws.efs import EFSPath
 from aibs_informatics_core.models.aws.s3 import S3Path
 from aibs_informatics_core.models.base import AwareIsoDateTime, PydanticBaseModel
+from aibs_informatics_core.models.data_sync import DataSyncFilterConfig
+from aibs_informatics_core.utils.filters import filter_paths, path_matches_filters
 from aibs_informatics_core.utils.logging import get_logger
 from aibs_informatics_core.utils.os_operations import find_all_paths
 from aibs_informatics_core.utils.time import BEGINNING_OF_TIME
@@ -153,6 +155,13 @@ class Node:
 @dataclass  # type: ignore[misc] # mypy #5374
 class BaseFileSystem:
     node: Node = field(init=False)
+    #: Number of objects encountered during the last :meth:`refresh`, counted
+    #: *before* include/exclude filters are applied. The tree itself only holds
+    #: the kept objects, so this is the only way to tell "the source was empty"
+    #: apart from "the filters matched nothing" -- which is what the prepare
+    #: handler needs in order to fail a typo'd pattern loudly rather than
+    #: launching Batch jobs against an empty input set.
+    total_objects_seen: int = field(init=False, default=0)
 
     def __post_init__(self):
         self.node = self.initialize_node()
@@ -162,7 +171,41 @@ class BaseFileSystem:
         raise NotImplementedError()
 
     @abstractmethod
-    def refresh(self, **kwargs):
+    def refresh(
+        self,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+        **kwargs,
+    ):
+        """Rebuild the tree, optionally keeping only the paths that pass filters.
+
+        Args:
+            filter_config: Optional include/exclude filters. When given, only
+                matching objects contribute to the tree -- and therefore to the
+                sizes that :meth:`partition` bins on.
+            filter_root: Root that patterns are matched relative to. Defaults to
+                this file system's own root. The distributed sync workflow splits
+                a sync into sub-requests rooted at sub-prefixes, and those must
+                pass the *original* root here or patterns stop matching.
+            **kwargs: Additional arguments passed to the underlying client.
+        """
+        raise NotImplementedError()
+
+    @property
+    def kept_objects(self) -> int:
+        """Number of objects retained by the last :meth:`refresh`."""
+        return self.node.object_count
+
+    @abstractmethod
+    def resolve_filter_root(self, filter_root: str | None) -> str:
+        """Resolve the root that filter patterns are matched relative to.
+
+        Args:
+            filter_root: Explicit root, or None to use this file system's own root.
+
+        Returns:
+            The root to relativize paths against.
+        """
         raise NotImplementedError()
 
     def partition(
@@ -235,9 +278,26 @@ class LocalFileSystem(BaseFileSystem):
     def initialize_node(self) -> Node:
         return Node(path_part=self.path.as_posix())
 
-    def refresh(self, **kwargs):
+    def resolve_filter_root(self, filter_root: str | None) -> str:
+        return filter_root if filter_root is not None else str(self.path)
+
+    def refresh(
+        self,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+        **kwargs,
+    ):
         self.node = self.initialize_node()
-        paths_to_visit = deque(find_all_paths(self.path, include_dirs=False, include_files=True))
+        all_paths = find_all_paths(self.path, include_dirs=False, include_files=True)
+        self.total_objects_seen = len(all_paths)
+        paths_to_visit = deque(
+            filter_paths(
+                all_paths,
+                root=self.resolve_filter_root(filter_root),
+                include=filter_config.include_patterns if filter_config else None,
+                exclude=filter_config.exclude_patterns if filter_config else None,
+            )
+        )
         while paths_to_visit:
             path = paths_to_visit.popleft()
             try:
@@ -263,10 +323,16 @@ class LocalFileSystem(BaseFileSystem):
                     raise ose
 
     @classmethod
-    def from_path(cls, path: str | Path, **kwargs) -> LocalFileSystem:
+    def from_path(
+        cls,
+        path: str | Path,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+        **kwargs,
+    ) -> LocalFileSystem:
         local_path = Path(path)
         local_root = LocalFileSystem(path=local_path)
-        local_root.refresh(**kwargs)
+        local_root.refresh(filter_config=filter_config, filter_root=filter_root, **kwargs)
         return local_root
 
 
@@ -277,8 +343,22 @@ class EFSFileSystem(LocalFileSystem):
     def initialize_node(self) -> Node:
         return Node(path_part=self.efs_path)
 
+    def resolve_filter_root(self, filter_root: str | None) -> str:
+        # The paths being filtered are local mount paths, but a caller upstream
+        # (e.g. the prepare handler) naturally expresses the filter root as the
+        # EFS path it was given. Translate so patterns anchor where they should.
+        if filter_root is not None and EFSPath.is_valid(filter_root):
+            return str(get_local_path(efs_path=EFSPath(filter_root)))
+        return super().resolve_filter_root(filter_root)
+
     @classmethod
-    def from_path(cls, path: str | Path, **kwargs) -> EFSFileSystem:
+    def from_path(
+        cls,
+        path: str | Path,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+        **kwargs,
+    ) -> EFSFileSystem:
         if isinstance(path, str) and EFSPath.is_valid(path):
             efs_path = EFSPath(path)
             local_path = get_local_path(efs_path=efs_path)
@@ -287,7 +367,7 @@ class EFSFileSystem(LocalFileSystem):
             efs_path = get_efs_path(local_path=local_path)
 
         efs_root = EFSFileSystem(path=local_path, efs_path=efs_path)
-        efs_root.refresh(**kwargs)
+        efs_root.refresh(filter_config=filter_config, filter_root=filter_root, **kwargs)
         return efs_root
 
 
@@ -306,12 +386,41 @@ class S3FileSystem(BaseFileSystem):
     def initialize_node(self) -> Node:
         return Node(path_part=self.key)
 
-    def refresh(self, **kwargs):
+    @property
+    def s3_path(self) -> S3Path:
+        return S3Path.build(bucket_name=self.bucket, key=self.key)
+
+    def resolve_filter_root(self, filter_root: str | None) -> str:
+        return filter_root if filter_root is not None else str(self.s3_path)
+
+    def refresh(
+        self,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+        **kwargs,
+    ):
         self.node = self.initialize_node()
+        self.total_objects_seen = 0
         s3 = get_s3_resource(**kwargs)
         bucket = s3.Bucket(self.bucket)
 
+        resolved_filter_root = self.resolve_filter_root(filter_root)
+        include = filter_config.include_patterns if filter_config else None
+        exclude = filter_config.exclude_patterns if filter_config else None
+
+        # Filtering happens in-loop rather than via `list_s3_paths` so that a
+        # filtered prefix is still walked in a single streaming pass -- these
+        # prefixes run to millions of objects and we never want the full listing
+        # materialized just to throw most of it away.
         for obj in bucket.objects.filter(Prefix=self.key):
+            self.total_objects_seen += 1
+            if not path_matches_filters(
+                S3Path.build(bucket_name=self.bucket, key=obj.key),
+                root=resolved_filter_root,
+                include=include,
+                exclude=exclude,
+            ):
+                continue
             self.node.add_object(
                 path=removeprefix(obj.key, self.key),
                 size=obj.size,
@@ -319,17 +428,41 @@ class S3FileSystem(BaseFileSystem):
             )
 
     @classmethod
-    def from_path(cls, path: str, **kwargs) -> S3FileSystem:
+    def from_path(
+        cls,
+        path: str,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+        **kwargs,
+    ) -> S3FileSystem:
         s3_path = S3Path(path)
         s3_root = S3FileSystem(bucket=s3_path.bucket, key=s3_path.key)
-        s3_root.refresh(**kwargs)
+        s3_root.refresh(filter_config=filter_config, filter_root=filter_root, **kwargs)
         return s3_root
 
 
-def get_file_system(path: str | Path) -> BaseFileSystem:
+def get_file_system(
+    path: str | Path,
+    filter_config: DataSyncFilterConfig | None = None,
+    filter_root: str | None = None,
+) -> BaseFileSystem:
+    """Build the file system tree appropriate to the given path.
+
+    Args:
+        path: An S3 path, EFS path, or local path.
+        filter_config: Optional include/exclude filters restricting the tree to
+            matching objects.
+        filter_root: Root that patterns are matched relative to. Defaults to
+            ``path``.
+
+    Returns:
+        The refreshed file system.
+    """
     if isinstance(path, str) and S3Path.is_valid(path):
-        return S3FileSystem.from_path(path)
+        return S3FileSystem.from_path(path, filter_config=filter_config, filter_root=filter_root)
     elif isinstance(path, str) and EFSPath.is_valid(path):
-        return EFSFileSystem.from_path(path)
+        return EFSFileSystem.from_path(path, filter_config=filter_config, filter_root=filter_root)
     else:
-        return LocalFileSystem.from_path(path)
+        return LocalFileSystem.from_path(
+            path, filter_config=filter_config, filter_root=filter_root
+        )

--- a/src/aibs_informatics_aws_utils/data_sync/operations.py
+++ b/src/aibs_informatics_aws_utils/data_sync/operations.py
@@ -10,6 +10,7 @@ from aibs_informatics_core.models.aws.efs import EFSPath
 from aibs_informatics_core.models.aws.s3 import S3KeyPrefix, S3Path
 from aibs_informatics_core.models.data_sync import (
     DataSyncConfig,
+    DataSyncFilterConfig,
     DataSyncRequest,
     DataSyncResult,
     DataSyncTask,
@@ -25,6 +26,7 @@ from aibs_informatics_core.utils.file_operations import (
     move_path,
     remove_path,
 )
+from aibs_informatics_core.utils.filters import filter_paths
 from aibs_informatics_core.utils.logging import LoggingMixin, get_logger
 from aibs_informatics_core.utils.os_operations import find_all_paths
 from botocore.client import Config
@@ -66,7 +68,13 @@ class DataSyncOperations(LoggingMixin):
     def botocore_config(self) -> Config:
         return get_botocore_config(max_pool_connections=self.config.max_concurrency)
 
-    def sync_local_to_s3(self, source_path: LocalPath, destination_path: S3Path) -> DataSyncResult:
+    def sync_local_to_s3(
+        self,
+        source_path: LocalPath,
+        destination_path: S3Path,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+    ) -> DataSyncResult:
         source_path = self.sanitize_local_path(source_path)
         if not source_path.exists():
             if self.config.fail_if_missing:
@@ -86,21 +94,39 @@ class DataSyncOperations(LoggingMixin):
         sync_paths(
             source_path=source_path,
             destination_path=destination_path,
+            include=filter_config.include_patterns if filter_config else None,
+            exclude=filter_config.exclude_patterns if filter_config else None,
+            filter_root=filter_root,
             transfer_config=self.s3_transfer_config,
             config=self.botocore_config,
             force=self.config.force,
             size_only=self.config.size_only,
-            delete=True,
+            delete=self.config.delete,
         )
         result = DataSyncResult()
         if self.config.include_detailed_response:
-            result.files_transferred = len(find_all_paths(source_path, include_dirs=False))
-            result.bytes_transferred = get_path_size_bytes(source_path)
+            # Counted over the *filtered* source. Measuring the whole source here
+            # would report everything the caller pointed at rather than what the
+            # sync actually moved, which with filters is usually far less.
+            transferred_paths = filter_paths(
+                find_all_paths(source_path, include_dirs=False),
+                root=filter_root if filter_root is not None else str(source_path),
+                include=filter_config.include_patterns if filter_config else None,
+                exclude=filter_config.exclude_patterns if filter_config else None,
+            )
+            result.files_transferred = len(transferred_paths)
+            result.bytes_transferred = sum(get_path_size_bytes(Path(p)) for p in transferred_paths)
         if not self.config.retain_source_data:
             remove_path(source_path)
         return result
 
-    def sync_s3_to_local(self, source_path: S3Path, destination_path: LocalPath) -> DataSyncResult:
+    def sync_s3_to_local(
+        self,
+        source_path: S3Path,
+        destination_path: LocalPath,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
+    ) -> DataSyncResult:
         self.logger.info(f"Downloading s3 content from {source_path} -> {destination_path}")
         start_time = datetime.now(tz=timezone.utc)
         destination_path = self.sanitize_local_path(destination_path)
@@ -158,6 +184,9 @@ class DataSyncOperations(LoggingMixin):
                 _sync_paths(
                     source_path=source_path,
                     destination_path=tmp_destination_path,
+                    include=filter_config.include_patterns if filter_config else None,
+                    exclude=filter_config.exclude_patterns if filter_config else None,
+                    filter_root=filter_root,
                     transfer_config=self.s3_transfer_config,
                     config=self.botocore_config,
                     force=self.config.force,
@@ -171,11 +200,14 @@ class DataSyncOperations(LoggingMixin):
             _sync_paths(
                 source_path=source_path,
                 destination_path=destination_path,
+                include=filter_config.include_patterns if filter_config else None,
+                exclude=filter_config.exclude_patterns if filter_config else None,
+                filter_root=filter_root,
                 transfer_config=self.s3_transfer_config,
                 config=self.botocore_config,
                 force=self.config.force,
                 size_only=self.config.size_only,
-                delete=True,
+                delete=self.config.delete,
             )
 
         self.logger.info(f"Updating last modified time on local files to at least {start_time}")
@@ -195,10 +227,31 @@ class DataSyncOperations(LoggingMixin):
         return result
 
     def sync_local_to_local(
-        self, source_path: LocalPath, destination_path: LocalPath
+        self,
+        source_path: LocalPath,
+        destination_path: LocalPath,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
     ) -> DataSyncResult:
         source_path = self.sanitize_local_path(source_path)
         destination_path = self.sanitize_local_path(destination_path)
+
+        # TODO: implement include/exclude filtering for local -> local sync.
+        #   Unlike the other three directions, this one does not go through
+        #   `sync_paths`; it delegates to `copy_path`/`move_path`, which copy a
+        #   tree wholesale and take no patterns. Supporting filters here means
+        #   either teaching those helpers about patterns or walking the source
+        #   and transferring file by file. Until then a filtered local -> local
+        #   sync copies *everything*, so warn loudly rather than let a silently
+        #   complete full copy look like a successful filtered one.
+        if filter_config is not None and (filter_config.include or filter_config.exclude):
+            self.logger.warning(
+                f"Include/exclude filters are NOT supported for local -> local sync "
+                f"({source_path} -> {destination_path}). "
+                f"include={filter_config.include}, exclude={filter_config.exclude} "
+                f"will be IGNORED and the full source will be copied."
+            )
+
         self.logger.info(f"Copying local content from {source_path} -> {destination_path}")
         start_time = datetime.now(tz=timezone.utc)
 
@@ -227,6 +280,8 @@ class DataSyncOperations(LoggingMixin):
         source_path: S3Path,
         destination_path: S3Path,
         source_path_prefix: S3KeyPrefix | None = None,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
     ) -> DataSyncResult:
         self.logger.info(f"Syncing s3 content from {source_path} -> {destination_path}")
 
@@ -244,11 +299,14 @@ class DataSyncOperations(LoggingMixin):
             source_path=source_path,
             destination_path=destination_path,
             source_path_prefix=source_path_prefix,
+            include=filter_config.include_patterns if filter_config else None,
+            exclude=filter_config.exclude_patterns if filter_config else None,
+            filter_root=filter_root,
             transfer_config=self.s3_transfer_config,
             config=self.botocore_config,
             force=self.config.force,
             size_only=self.config.size_only,
-            delete=True,
+            delete=self.config.delete,
         )
         if not self.config.retain_source_data:
             delete_s3_path(s3_path=source_path)
@@ -265,28 +323,38 @@ class DataSyncOperations(LoggingMixin):
         source_path: LocalPath | S3Path,
         destination_path: LocalPath | S3Path,
         source_path_prefix: str | None = None,
+        filter_config: DataSyncFilterConfig | None = None,
+        filter_root: str | None = None,
     ) -> DataSyncResult:
         if isinstance(source_path, S3Path) and isinstance(destination_path, S3Path):
             return self.sync_s3_to_s3(
                 source_path=source_path,
                 destination_path=destination_path,
                 source_path_prefix=S3KeyPrefix(source_path_prefix) if source_path_prefix else None,
+                filter_config=filter_config,
+                filter_root=filter_root,
             )
 
         elif isinstance(source_path, S3Path):
             return self.sync_s3_to_local(
                 source_path=source_path,
                 destination_path=cast(LocalPath, destination_path),
+                filter_config=filter_config,
+                filter_root=filter_root,
             )
         elif isinstance(destination_path, S3Path):
             return self.sync_local_to_s3(
                 source_path=cast(LocalPath, source_path),
                 destination_path=destination_path,
+                filter_config=filter_config,
+                filter_root=filter_root,
             )
         else:
             return self.sync_local_to_local(
                 source_path=source_path,
                 destination_path=destination_path,
+                filter_config=filter_config,
+                filter_root=filter_root,
             )
 
     def sync_task(self, task: DataSyncTask) -> DataSyncResult:
@@ -294,6 +362,8 @@ class DataSyncOperations(LoggingMixin):
             source_path=task.source_path,
             destination_path=task.destination_path,
             source_path_prefix=task.source_path_prefix,
+            filter_config=task.filter_config,
+            filter_root=task.filter_root,
         )
 
     @classmethod
@@ -319,8 +389,11 @@ def sync_data(
     source_path: S3Path | LocalPath,
     destination_path: S3Path | LocalPath,
     source_path_prefix: str | None = None,
+    filter_config: DataSyncFilterConfig | None = None,
+    filter_root: str | None = None,
     max_concurrency: int = 10,
     retain_source_data: bool = True,
+    delete: bool = True,
     require_lock: bool = False,
     force: bool = False,
     size_only: bool = False,
@@ -328,12 +401,41 @@ def sync_data(
     remote_to_local_config: RemoteToLocalConfig | None = None,
     include_detailed_response: bool = False,
 ):
+    """Sync data from a source path to a destination path.
+
+    Args:
+        source_path: Path to sync data from.
+        destination_path: Path to sync data to.
+        source_path_prefix: Optional S3 key prefix scoping the source.
+        filter_config: Optional include/exclude filters describing what to move.
+            Not supported for local -> local syncs, which warn and copy in full.
+        filter_root: Root that filter patterns are matched relative to. Defaults
+            to the source path; set explicitly when syncing a sub-prefix of the
+            root the patterns were written against.
+        max_concurrency: Maximum number of concurrent transfer operations.
+        retain_source_data: Whether to keep source data after syncing.
+        delete: Whether to delete destination paths absent from the (filtered)
+            source. Note that this combines destructively with ``filter_config``
+            -- see ``DataSyncConfig.delete``.
+        require_lock: Whether to acquire a lock on the destination path.
+        force: Whether to transfer regardless of existing destination content.
+        size_only: Whether to compare only file sizes when deciding to transfer.
+        fail_if_missing: Whether to raise if the source path does not exist.
+        remote_to_local_config: Options specific to remote-to-local syncs.
+        include_detailed_response: Whether to compute detailed transfer metrics.
+
+    Returns:
+        The sync result.
+    """
     request = DataSyncRequest(
         source_path=source_path,
         destination_path=destination_path,
         source_path_prefix=S3KeyPrefix(source_path_prefix) if source_path_prefix else None,
+        filter_config=filter_config,
+        filter_root=filter_root,
         max_concurrency=max_concurrency,
         retain_source_data=retain_source_data,
+        delete=delete,
         require_lock=require_lock,
         force=force,
         size_only=size_only,

--- a/src/aibs_informatics_aws_utils/s3.py
+++ b/src/aibs_informatics_aws_utils/s3.py
@@ -11,7 +11,6 @@ from enum import Enum
 from functools import lru_cache
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from re import Pattern
 from tempfile import NamedTemporaryFile
 from typing import (
     TYPE_CHECKING,
@@ -39,6 +38,7 @@ from aibs_informatics_core.utils.file_operations import (
     remove_path,
     strip_path_root,
 )
+from aibs_informatics_core.utils.filters import Patterns, filter_paths
 from aibs_informatics_core.utils.json import JSON
 from aibs_informatics_core.utils.logging import get_logger
 from aibs_informatics_core.utils.multiprocessing import parallel_starmap
@@ -693,8 +693,9 @@ def sync_paths(
     source_path: Path | S3Path,
     destination_path: Path | S3Path,
     source_path_prefix: str | None = None,
-    include: list[Pattern] | None = None,
-    exclude: list[Pattern] | None = None,
+    include: Patterns = None,
+    exclude: Patterns = None,
+    filter_root: str | None = None,
     extra_args: dict[str, Any] | None = None,
     transfer_config: TransferConfig | None = None,
     force: bool = False,
@@ -702,6 +703,37 @@ def sync_paths(
     delete: bool = False,
     **kwargs,
 ) -> list[S3TransferResponse]:
+    """Sync the contents of a source path to a destination path.
+
+    Include/exclude patterns follow the shared contract in
+    :mod:`aibs_informatics_core.utils.filters`: regexes matched with
+    ``fullmatch`` against the path relative to ``filter_root``, with exclude
+    winning over include. The same helper is applied to both the S3 and the
+    local source branch, so a pattern behaves identically either side.
+
+    Args:
+        source_path (Union[Path, S3Path]): Path to sync from.
+        destination_path (Union[Path, S3Path]): Path to sync to.
+        source_path_prefix (Optional[str]): Optional prefix stripped from source
+            paths when computing destination paths. Defaults to the source path.
+        include (Patterns): Optional regex pattern(s) of files to sync.
+        exclude (Patterns): Optional regex pattern(s) of files not to sync.
+        filter_root (Optional[str]): Root that patterns are matched relative to.
+            Defaults to ``source_path``. Callers syncing a sub-prefix of the root
+            the patterns were written against must set this explicitly.
+        extra_args (Optional[Dict[str, Any]]): Extra arguments for the transfers.
+        transfer_config (Optional[TransferConfig]): Transfer configuration.
+        force (bool): Whether to transfer regardless of destination content.
+        size_only (bool): Whether to compare only sizes when deciding to transfer.
+        delete (bool): Whether to delete destination paths absent from the
+            (filtered) source. Note that filters narrow what counts as "the
+            source", so with filters this deletes destination files the filters
+            exclude. See ``DataSyncConfig.delete``.
+        **kwargs: Additional arguments passed to the S3 client.
+
+    Returns:
+        List of transfer responses.
+    """
     logger.info(f"Syncing {source_path} to {destination_path}")
 
     source_path_key = source_path.key if isinstance(source_path, S3Path) else str(source_path)
@@ -717,18 +749,30 @@ def sync_paths(
             s3_path=source_path.with_folder_suffix,
             include=include,
             exclude=exclude,
+            filter_root=filter_root,
             **kwargs,
         )
         if is_object(source_path, **kwargs) and source_path not in nested_source_paths:
-            nested_source_paths.insert(0, source_path)
+            # A source that is itself an object is filtered against the same root as
+            # everything else, rather than being unconditionally included.
+            if filter_paths(
+                [source_path],
+                root=filter_root if filter_root is not None else source_path.with_folder_suffix,
+                include=include,
+                exclude=exclude,
+            ):
+                nested_source_paths.insert(0, source_path)
     else:
+        # Listed unfiltered and then filtered through the shared helper, so that the
+        # anchor is `filter_root` rather than always the source path. `find_paths`
+        # would anchor at its own `root` argument.
         nested_source_paths = [
             Path(p)  # type: ignore
-            for p in find_paths(
-                root=source_path,
-                include_dirs=False,
-                includes=include,  # type: ignore
-                excludes=exclude,  # type: ignore
+            for p in filter_paths(
+                find_paths(root=source_path, include_dirs=False),
+                root=filter_root if filter_root is not None else source_path,
+                include=include,
+                exclude=exclude,
             )
         ]
 
@@ -970,16 +1014,18 @@ def copy_s3_object(
 
 def delete_s3_path(
     s3_path: S3Path,
-    include: list[Pattern] | None = None,
-    exclude: list[Pattern] | None = None,
+    include: Patterns = None,
+    exclude: Patterns = None,
     **kwargs,
 ):
     """Delete an S3 path (object or prefix).
 
     Args:
         s3_path (S3Path): Path or key prefix to delete.
-        include (Optional[List[Pattern]]): Patterns to include. Defaults to None.
-        exclude (Optional[List[Pattern]]): Patterns to exclude. Defaults to None.
+        include (Patterns): Patterns to include, matched relative to ``s3_path``.
+            Defaults to None.
+        exclude (Patterns): Patterns to exclude, matched relative to ``s3_path``.
+            Defaults to None.
         **kwargs: Additional arguments passed to the S3 client.
     """
     logger.info(f"Deleting S3 path {s3_path}")
@@ -1019,8 +1065,8 @@ def delete_s3_objects(s3_paths: list[S3Path], **kwargs):
 def move_s3_path(
     source_path: S3Path,
     destination_path: S3Path,
-    include: list[Pattern] | None = None,
-    exclude: list[Pattern] | None = None,
+    include: Patterns = None,
+    exclude: Patterns = None,
     extra_args: dict[str, Any] | None = None,
     transfer_config: TransferConfig | None = None,
     **kwargs,
@@ -1032,8 +1078,10 @@ def move_s3_path(
     Args:
         source_path (S3Path): Source S3 path.
         destination_path (S3Path): Destination S3 path.
-        include (Optional[List[Pattern]]): Patterns to include. Defaults to None.
-        exclude (Optional[List[Pattern]]): Patterns to exclude. Defaults to None.
+        include (Patterns): Patterns to include, matched relative to
+            ``source_path``. Defaults to None.
+        exclude (Patterns): Patterns to exclude, matched relative to
+            ``source_path``. Defaults to None.
         extra_args (Optional[Dict[str, Any]]): Extra arguments for the copy. Defaults to None.
         transfer_config (Optional[TransferConfig]): Transfer configuration. Defaults to None.
         **kwargs: Additional arguments passed to the S3 client.
@@ -1055,50 +1103,39 @@ def move_s3_path(
 
 def list_s3_paths(
     s3_path: S3Path,
-    include: list[Pattern] | None = None,
-    exclude: list[Pattern] | None = None,
+    include: Patterns = None,
+    exclude: Patterns = None,
+    filter_root: str | None = None,
     **kwargs,
 ) -> list[S3Path]:
     """List all S3 paths under a Key prefix (as defined by S3 path).
 
-    Include/Exclude patterns are applied to the RELATIVE KEY PATH.
+    Include/exclude patterns follow the shared contract in
+    :mod:`aibs_informatics_core.utils.filters`: they are regular expressions
+    matched with ``fullmatch`` against the path *relative to the filter root*,
+    and exclude wins over include.
 
-    Logic for how the include/exclude patterns are applied:
-
-    - **include/exclude**: pattern provided? Y/N
-    - **I/E Match**: If pattern provided, does S3 relative Key match? Y/N
-
-    | include | I Match | exclude | E Match | Append? |
-    |---------|---------|---------|---------|--------|
-    | N       | -       | N       | -       | Y      |
-    | Y       | Y       | N       | -       | Y      |
-    | Y       | N       | N       | -       | N      |
-    | N       | -       | Y       | Y       | N      |
-    | N       | -       | Y       | N       | Y      |
-    | Y       | Y       | Y       | Y       | N      |
-    | Y       | N       | Y       | Y       | N      |
-    | Y       | Y       | Y       | N       | Y      |
-    | Y       | N       | Y       | N       | N      |
+    The filter root defaults to ``s3_path`` -- i.e. patterns are written against
+    the listing root, which is what a caller listing a prefix expects. A caller
+    that lists a *sub*-prefix of the prefix the patterns were written against
+    (as the distributed sync workflow does, splitting ``s3://b/run1/`` into
+    sub-requests rooted at ``s3://b/run1/sampleA/``) must pass ``filter_root``
+    explicitly, or patterns anchored at the original root silently stop matching.
 
     Args:
         s3_path (S3Path): The root key path under which to find objects.
-        include (Optional[List[Pattern]]): Optional list of regex patterns on which
-            to retain objects if matching any. Defaults to None.
-        exclude (Optional[List[Pattern]]): Optional list of regex patterns on which
-            to filter out objects if matching any. Defaults to None.
+        include (Patterns): Optional regex pattern(s) on which to retain objects
+            if matching any. Defaults to None (retain everything).
+        exclude (Patterns): Optional regex pattern(s) on which to filter out
+            objects if matching any. Takes precedence over ``include``.
+        filter_root (Optional[str]): Root that patterns are matched relative to.
+            Defaults to ``s3_path``.
         **kwargs: Additional arguments passed to the S3 client.
 
     Returns:
         List of S3 paths under root that satisfy filters.
     """
-
-    empty_include = (include is None) or (not any(include))
-    empty_exclude = (exclude is None) or (not any(exclude))
-
     s3 = get_s3_client(**kwargs)
-
-    def match_results(value: str, patterns: list[Pattern]) -> list[bool]:
-        return [_.match(value) is not None for _ in patterns]
 
     paginator = s3.get_paginator("list_objects_v2")
 
@@ -1106,11 +1143,14 @@ def list_s3_paths(
     for response in paginator.paginate(Bucket=s3_path.bucket, Prefix=s3_path.key):
         for item in response.get("Contents", []):
             key = item.get("Key", "")
-            relative_key = key[len(s3_path.key) :]
-            if empty_include or any(match_results(relative_key, include)):  # type: ignore
-                if empty_exclude or (not any(match_results(relative_key, exclude))):  # type: ignore
-                    s3_paths.append(S3Path.build(bucket_name=s3_path.bucket, key=key))
-    return s3_paths
+            s3_paths.append(S3Path.build(bucket_name=s3_path.bucket, key=key))
+
+    return filter_paths(
+        s3_paths,
+        root=filter_root if filter_root is not None else s3_path,
+        include=include,
+        exclude=exclude,
+    )
 
 
 class PresignedUrlAction(Enum):

--- a/test/aibs_informatics_aws_utils/data_sync/test_file_system.py
+++ b/test/aibs_informatics_aws_utils/data_sync/test_file_system.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytz
 from aibs_informatics_core.models.aws.efs import EFSPath
 from aibs_informatics_core.models.aws.s3 import S3Path, S3PathStats
+from aibs_informatics_core.models.data_sync import DataSyncFilterConfig
 from aibs_informatics_core.utils.time import get_current_time
 from aibs_informatics_core.utils.tools.strtools import removeprefix
 
@@ -16,6 +17,7 @@ from aibs_informatics_aws_utils.data_sync.file_system import (
     LocalFileSystem,
     Node,
     S3FileSystem,
+    get_file_system,
 )
 from aibs_informatics_aws_utils.efs import MountPointConfiguration
 from aibs_informatics_aws_utils.efs.mount_point import detect_mount_points
@@ -271,6 +273,128 @@ class LocalFileSystemTests(BaseTest):
         local_node_paths = {removeprefix(node.path, f"{local_path}/") for node in local_nodes}
 
         self.assertSetEqual(expected_node_paths, local_node_paths)
+
+    def test__refresh__filters__tree_holds_only_kept_paths(self):
+        local_path = self.create_local_file_system(
+            {"A/keep.bam": (5,), "A/drop.txt": (7,), "B/keep.bam": (3,)}
+        )
+        local_root = LocalFileSystem.from_path(
+            str(local_path), filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertEqual(local_root.node.object_count, 2)
+        self.assertEqual(local_root.node.size_bytes, 8)
+        self.assertIsNone(local_root.node["A"].get("drop.txt"))
+
+    def test__refresh__filters__total_objects_seen_counts_pre_filter(self):
+        local_path = self.create_local_file_system(
+            {"A/keep.bam": (5,), "A/drop.txt": (7,), "B/drop.txt": (3,)}
+        )
+        local_root = LocalFileSystem.from_path(
+            str(local_path), filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        # The whole point of the counter: 3 objects were there, filters kept 1.
+        # Without it a zero-match filter is indistinguishable from an empty source.
+        self.assertEqual(local_root.total_objects_seen, 3)
+        self.assertEqual(local_root.kept_objects, 1)
+
+    def test__refresh__filters__zero_matches_distinguishable_from_empty_source(self):
+        populated = self.create_local_file_system({"A/x.txt": (5,)})
+        empty = self.tmp_path()
+
+        no_match = LocalFileSystem.from_path(
+            str(populated), filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+        empty_fs = LocalFileSystem.from_path(str(empty))
+
+        self.assertEqual(no_match.kept_objects, 0)
+        self.assertEqual(empty_fs.kept_objects, 0)
+        self.assertEqual(no_match.total_objects_seen, 1)
+        self.assertEqual(empty_fs.total_objects_seen, 0)
+
+    def test__refresh__filters__exclude_wins_over_include(self):
+        local_path = self.create_local_file_system({"A/x.bam": (5,), "A/y.bam": (7,)})
+        local_root = LocalFileSystem.from_path(
+            str(local_path),
+            filter_config=DataSyncFilterConfig(include=r".*\.bam", exclude=r"A/y\.bam"),
+        )
+
+        self.assertEqual(local_root.kept_objects, 1)
+        self.assertEqual(local_root.node.size_bytes, 5)
+
+    def test__refresh__filters__patterns_are_relative_and_fullmatched(self):
+        local_path = self.create_local_file_system({"sample/x.bam": (5,), "other/y.bam": (7,)})
+
+        # Relative to the root -- `find_paths` used to match the full absolute
+        # path here, so a root-relative pattern like this matched nothing.
+        relative = LocalFileSystem.from_path(
+            str(local_path), filter_config=DataSyncFilterConfig(include=r"sample/.*")
+        )
+        self.assertEqual(relative.node.size_bytes, 5)
+
+        # Fullmatch -- a bare fragment does not match.
+        fragment = LocalFileSystem.from_path(
+            str(local_path), filter_config=DataSyncFilterConfig(include=r"sample")
+        )
+        self.assertEqual(fragment.kept_objects, 0)
+
+    def test__partition__filters__bins_on_kept_bytes_not_total(self):
+        """The property the entire distributed speedup depends on.
+
+        If `partition` binned on unfiltered sizes, a request for a small slice of
+        a large prefix would produce bins sized for the whole prefix and every
+        batch job would run nearly empty.
+        """
+        local_path = self.create_local_file_system(
+            {"A/keep.bam": (4,), "A/drop.txt": (100,), "B/keep.bam": (4,), "B/drop.txt": (100,)}
+        )
+
+        unfiltered = LocalFileSystem.from_path(str(local_path))
+        filtered = LocalFileSystem.from_path(
+            str(local_path), filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertEqual(unfiltered.node.size_bytes, 208)
+        self.assertEqual(filtered.node.size_bytes, 8)
+
+        # 8 kept bytes fit under the limit, so the filtered tree needs no split
+        # at all, while the unfiltered one is driven down to object level.
+        limit = 10
+        filtered_nodes = filtered.partition(size_bytes_limit=limit)
+        unfiltered_nodes = unfiltered.partition(size_bytes_limit=limit)
+
+        self.assertSetEqual(
+            {removeprefix(node.path, f"{local_path}/") for node in filtered_nodes}, {""}
+        )
+        self.assertGreater(len(unfiltered_nodes), len(filtered_nodes))
+        for node in filtered_nodes:
+            self.assertLessEqual(node.size_bytes, limit)
+
+    def test__partition__filters__respects_explicit_filter_root(self):
+        local_path = self.create_local_file_system({"sampleA/x.bam": (4,), "sampleA/y.txt": (9,)})
+        sub_path = local_path / "sampleA"
+
+        # Patterns written against `local_path` but the sync rooted at `sampleA/`:
+        # without the anchor they match nothing, with it they behave as written.
+        filter_config = DataSyncFilterConfig(include=r"sampleA/.*\.bam")
+
+        unanchored = LocalFileSystem.from_path(str(sub_path), filter_config=filter_config)
+        self.assertEqual(unanchored.node.size_bytes, 0)
+
+        anchored = LocalFileSystem.from_path(
+            str(sub_path), filter_config=filter_config, filter_root=str(local_path)
+        )
+        self.assertEqual(anchored.node.size_bytes, 4)
+
+    def test__get_file_system__passes_filters_through(self):
+        local_path = self.create_local_file_system({"A/keep.bam": (5,), "A/drop.txt": (7,)})
+        fs = get_file_system(
+            str(local_path), filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertIsInstance(fs, LocalFileSystem)
+        self.assertEqual(fs.node.size_bytes, 5)
 
 
 class EFSFileSystemTests(EFSTestsBase):
@@ -575,6 +699,162 @@ class S3FileSystemTests(AwsBaseTest):
             size_bytes_limit=10,
             object_count_limit=10,
             expected_s3_node_keys={f"{self.KEY_PREFIX}"},
+        )
+
+    def test__refresh__filters__tree_holds_only_kept_objects(self):
+        s3_root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        last_modified = get_current_time()
+        self.setUpMockBucket(
+            s3_root_uri,
+            {
+                "A/keep.bam": S3PathStats(last_modified, 5, 1),
+                "A/drop.txt": S3PathStats(last_modified, 7, 1),
+                "B/keep.bam": S3PathStats(last_modified, 3, 1),
+            },
+        )
+
+        s3_root = S3FileSystem.from_path(
+            s3_root_uri, filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertEqual(s3_root.node.object_count, 2)
+        self.assertEqual(s3_root.node.size_bytes, 8)
+        self.assertIsNone(s3_root.node["A"].get("drop.txt"))
+
+    def test__refresh__filters__total_objects_seen_counts_pre_filter(self):
+        s3_root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        last_modified = get_current_time()
+        self.setUpMockBucket(
+            s3_root_uri,
+            {
+                "A/keep.bam": S3PathStats(last_modified, 5, 1),
+                "A/drop.txt": S3PathStats(last_modified, 7, 1),
+                "B/drop.txt": S3PathStats(last_modified, 3, 1),
+            },
+        )
+
+        s3_root = S3FileSystem.from_path(
+            s3_root_uri, filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertEqual(s3_root.total_objects_seen, 3)
+        self.assertEqual(s3_root.kept_objects, 1)
+
+    def test__refresh__filters__zero_matches_still_reports_objects_seen(self):
+        s3_root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        last_modified = get_current_time()
+        self.setUpMockBucket(s3_root_uri, {"A/x.txt": S3PathStats(last_modified, 5, 1)})
+
+        s3_root = S3FileSystem.from_path(
+            s3_root_uri, filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertEqual(s3_root.kept_objects, 0)
+        self.assertEqual(s3_root.total_objects_seen, 1)
+
+    def test__refresh__filters__exclude_wins_over_include(self):
+        s3_root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        last_modified = get_current_time()
+        self.setUpMockBucket(
+            s3_root_uri,
+            {
+                "A/x.bam": S3PathStats(last_modified, 5, 1),
+                "A/y.bam": S3PathStats(last_modified, 7, 1),
+            },
+        )
+
+        s3_root = S3FileSystem.from_path(
+            s3_root_uri,
+            filter_config=DataSyncFilterConfig(include=r".*\.bam", exclude=r"A/y\.bam"),
+        )
+
+        self.assertEqual(s3_root.kept_objects, 1)
+        self.assertEqual(s3_root.node.size_bytes, 5)
+
+    def test__refresh__filters__patterns_are_fullmatched(self):
+        s3_root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        last_modified = get_current_time()
+        self.setUpMockBucket(s3_root_uri, {"A/x.bam": S3PathStats(last_modified, 5, 1)})
+
+        fragment = S3FileSystem.from_path(
+            s3_root_uri, filter_config=DataSyncFilterConfig(include=r"A")
+        )
+        self.assertEqual(fragment.kept_objects, 0)
+
+        full = S3FileSystem.from_path(
+            s3_root_uri, filter_config=DataSyncFilterConfig(include=r"A/.*")
+        )
+        self.assertEqual(full.kept_objects, 1)
+
+    def test__partition__filters__bins_on_kept_bytes_not_total(self):
+        """The property the entire distributed speedup depends on."""
+        s3_root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        last_modified = get_current_time()
+        self.setUpMockBucket(
+            s3_root_uri,
+            {
+                "A/keep.bam": S3PathStats(last_modified, 4, 1),
+                "A/drop.txt": S3PathStats(last_modified, 100, 1),
+                "B/keep.bam": S3PathStats(last_modified, 4, 1),
+                "B/drop.txt": S3PathStats(last_modified, 100, 1),
+            },
+        )
+
+        unfiltered = S3FileSystem.from_path(s3_root_uri)
+        filtered = S3FileSystem.from_path(
+            s3_root_uri, filter_config=DataSyncFilterConfig(include=r".*\.bam")
+        )
+
+        self.assertEqual(unfiltered.node.size_bytes, 208)
+        self.assertEqual(filtered.node.size_bytes, 8)
+
+        limit = 10
+        filtered_nodes = filtered.partition(size_bytes_limit=limit)
+        unfiltered_nodes = unfiltered.partition(size_bytes_limit=limit)
+
+        # Kept bytes fit in one bin; the unfiltered tree is driven to object level.
+        self.assertSetEqual({node.path for node in filtered_nodes}, {self.KEY_PREFIX})
+        self.assertGreater(len(unfiltered_nodes), len(filtered_nodes))
+        for node in filtered_nodes:
+            self.assertLessEqual(node.size_bytes, limit)
+
+    def test__refresh__filters__respects_explicit_filter_root(self):
+        """A sub-request rooted at a sub-prefix still honors the original patterns."""
+        root_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=self.KEY_PREFIX)
+        sub_uri = S3Path.build(bucket_name=self.BUCKET_NAME, key=f"{self.KEY_PREFIX}sampleA/")
+        last_modified = get_current_time()
+        self.setUpMockBucket(
+            root_uri,
+            {
+                "sampleA/x.bam": S3PathStats(last_modified, 4, 1),
+                "sampleA/y.txt": S3PathStats(last_modified, 9, 1),
+            },
+        )
+
+        filter_config = DataSyncFilterConfig(include=r"sampleA/.*\.bam")
+
+        unanchored = S3FileSystem.from_path(sub_uri, filter_config=filter_config)
+        self.assertEqual(unanchored.node.size_bytes, 0)
+
+        anchored = S3FileSystem.from_path(
+            sub_uri, filter_config=filter_config, filter_root=str(root_uri)
+        )
+        self.assertEqual(anchored.node.size_bytes, 4)
+
+    def setUpMockBucket(self, s3_root_uri: S3Path, key_stats_map: Mapping[str, S3PathStats]):
+        self.mock_bucket(
+            s3_paths_stats=dict(
+                [
+                    self.get_s3_path_and_stats(
+                        key_suffix=key,
+                        size=stats.size_bytes,
+                        last_modified=stats.last_modified,
+                        bucket_name=s3_root_uri.bucket,
+                        key_prefix=self.KEY_PREFIX,
+                    )
+                    for key, stats in key_stats_map.items()
+                ]
+            )
         )
 
     def assertS3FileSystem_partition(

--- a/test/aibs_informatics_aws_utils/data_sync/test_operations.py
+++ b/test/aibs_informatics_aws_utils/data_sync/test_operations.py
@@ -1,13 +1,14 @@
 import sys
 from pathlib import Path
+from unittest import mock
 
 import moto
 from aibs_informatics_core.models.aws.s3 import S3Path
-from aibs_informatics_core.models.data_sync import RemoteToLocalConfig
+from aibs_informatics_core.models.data_sync import DataSyncFilterConfig, RemoteToLocalConfig
 from aibs_informatics_core.utils.os_operations import find_all_paths
 from pytest import mark
 
-from aibs_informatics_aws_utils.data_sync.operations import sync_data
+from aibs_informatics_aws_utils.data_sync.operations import DataSyncOperations, sync_data
 from aibs_informatics_aws_utils.s3 import get_s3_client, get_s3_resource, is_object, list_s3_paths
 from test.aibs_informatics_aws_utils.base import AwsBaseTest
 
@@ -447,6 +448,256 @@ class OperationsTests(AwsBaseTest):
             source_path=source_path, destination_path=destination_path, fail_if_missing=False
         )
         assert not is_object(destination_path)
+
+    # -----------------------------------------------------------------------
+    # include/exclude filtering (OCSDV-452)
+    # -----------------------------------------------------------------------
+
+    def test__sync_data__s3_to_s3__filtered__moves_only_matching_objects(self):
+        self.setUpBucket()
+        source_path = self.get_s3_path("source/path/")
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_object("source/path/sampleA/reads.bam", "hello")
+        self.put_object("source/path/sampleA/notes.txt", "did you hear me")
+
+        result = sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r".*\.bam"),
+            include_detailed_response=True,
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)},
+            {"destination/path/sampleA/reads.bam"},
+        )
+        self.assertEqual(result.files_transferred, 1)
+        self.assertEqual(result.bytes_transferred, 5)
+
+    def test__sync_data__s3_to_s3__filtered__exclude_wins_over_include(self):
+        self.setUpBucket()
+        source_path = self.get_s3_path("source/path/")
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_object("source/path/a.bam", "hello")
+        self.put_object("source/path/b.bam", "hello")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r".*\.bam", exclude=r"b\.bam"),
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)}, {"destination/path/a.bam"}
+        )
+
+    def test__sync_data__s3_to_s3__filtered__filter_root_anchors_patterns(self):
+        """A sub-request rooted at a sub-prefix honors patterns from the original root."""
+        self.setUpBucket()
+        root_path = self.get_s3_path("source/path/")
+        source_path = self.get_s3_path("source/path/sampleA/")
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_object("source/path/sampleA/reads.bam", "hello")
+        self.put_object("source/path/sampleA/notes.txt", "did you hear me")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r"sampleA/.*\.bam"),
+            filter_root=str(root_path),
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)}, {"destination/path/reads.bam"}
+        )
+
+    def test__sync_data__s3_to_local__filtered__downloads_only_matching_objects(self):
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        source_path = self.get_s3_path("source/path/")
+        destination_path = fs / "destination"
+        self.put_object("source/path/sampleA/reads.bam", "hello")
+        self.put_object("source/path/sampleA/notes.txt", "did you hear me")
+
+        result = sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r".*\.bam"),
+            include_detailed_response=True,
+        )
+
+        self.assertSetEqual(
+            {
+                str(p)[len(str(destination_path)) :].lstrip("/")
+                for p in find_all_paths(destination_path, False)
+            },
+            {"sampleA/reads.bam"},
+        )
+        self.assertEqual(result.files_transferred, 1)
+        self.assertEqual(result.bytes_transferred, 5)
+
+    def test__sync_data__s3_to_local__filtered__filter_root_anchors_patterns(self):
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        root_path = self.get_s3_path("source/path/")
+        source_path = self.get_s3_path("source/path/sampleA/")
+        destination_path = fs / "destination"
+        self.put_object("source/path/sampleA/reads.bam", "hello")
+        self.put_object("source/path/sampleA/notes.txt", "did you hear me")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r"sampleA/.*\.bam"),
+            filter_root=str(root_path),
+        )
+
+        self.assertSetEqual(
+            {Path(p).name for p in find_all_paths(destination_path, False)}, {"reads.bam"}
+        )
+
+    def test__sync_data__local_to_s3__filtered__uploads_only_matching_files(self):
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        source_path = fs / "source"
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_file(source_path / "sampleA" / "reads.bam", "hello")
+        self.put_file(source_path / "sampleA" / "notes.txt", "did you hear me")
+
+        result = sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r".*\.bam"),
+            include_detailed_response=True,
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)},
+            {"destination/path/sampleA/reads.bam"},
+        )
+        # Regression: these were computed over the UNFILTERED source, and so
+        # reported 2 files / 20 bytes for a sync that moved 1 file / 5 bytes.
+        self.assertEqual(result.files_transferred, 1)
+        self.assertEqual(result.bytes_transferred, 5)
+
+    def test__sync_data__local_to_s3__filtered__patterns_are_relative_to_source(self):
+        """`find_paths` matched the full absolute path, so this pattern matched nothing."""
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        source_path = fs / "source"
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_file(source_path / "sample" / "reads.bam", "hello")
+        self.put_file(source_path / "other" / "reads.bam", "did you hear me")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r"sample/.*"),
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)},
+            {"destination/path/sample/reads.bam"},
+        )
+
+    def test__sync_data__local_to_s3__filtered__filter_root_anchors_patterns(self):
+        fs = self.setUpLocalFS()
+        self.setUpBucket()
+        root_path = fs / "source"
+        source_path = root_path / "sampleA"
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_file(source_path / "reads.bam", "hello")
+        self.put_file(source_path / "notes.txt", "did you hear me")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r"sampleA/.*\.bam"),
+            filter_root=str(root_path),
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)}, {"destination/path/reads.bam"}
+        )
+
+    def test__sync_data__delete__false__retains_unmatched_destination_files(self):
+        """`delete` is the gate on the filtered-sync-deletes-extra-files hazard."""
+        self.setUpBucket()
+        source_path = self.get_s3_path("source/path/")
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_object("source/path/a.bam", "hello")
+        self.put_object("destination/path/stale.txt", "i was here first")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            delete=False,
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)},
+            {"destination/path/a.bam", "destination/path/stale.txt"},
+        )
+
+    def test__sync_data__delete__true__removes_filtered_out_destination_files(self):
+        """Documented hazard: a filtered sync with delete=True mirrors, so it deletes."""
+        self.setUpBucket()
+        source_path = self.get_s3_path("source/path/")
+        destination_path = self.get_s3_path("destination/path/")
+        self.put_object("source/path/a.bam", "hello")
+        self.put_object("source/path/b.txt", "did you hear me")
+        # An earlier unfiltered copy already sitting at the destination.
+        self.put_object("destination/path/b.txt", "did you hear me")
+
+        sync_data(
+            source_path=source_path,
+            destination_path=destination_path,
+            filter_config=DataSyncFilterConfig(include=r".*\.bam"),
+            delete=True,
+        )
+
+        self.assertSetEqual(
+            {p.key for p in list_s3_paths(destination_path)}, {"destination/path/a.bam"}
+        )
+
+    def test__sync_data__local_to_local__filtered__warns_and_copies_everything(self):
+        fs = self.setUpLocalFS()
+        source_path = fs / "source"
+        destination_path = fs / "destination"
+        self.put_file(source_path / "reads.bam", "hello")
+        self.put_file(source_path / "notes.txt", "did you hear me")
+
+        with self.assertLogs(
+            "aibs_informatics_aws_utils.data_sync.operations", level="WARNING"
+        ) as logs:
+            sync_data(
+                source_path=source_path,
+                destination_path=destination_path,
+                filter_config=DataSyncFilterConfig(include=r".*\.bam"),
+            )
+
+        self.assertTrue(
+            any("NOT supported for local -> local" in message for message in logs.output),
+            f"expected an unsupported-filter warning, got: {logs.output}",
+        )
+        # Deliberately unimplemented: the full source is copied regardless.
+        self.assertPathsEqual(source_path, destination_path, 2)
+
+    def test__sync_data__local_to_local__no_filters__does_not_warn(self):
+        fs = self.setUpLocalFS()
+        source_path = fs / "source"
+        destination_path = fs / "destination"
+        self.put_file(source_path / "reads.bam", "hello")
+
+        with mock.patch.object(DataSyncOperations, "logger") as mock_logger:
+            sync_data(source_path=source_path, destination_path=destination_path)
+
+        self.assertFalse(
+            any(
+                "NOT supported for local -> local" in str(call)
+                for call in mock_logger.warning.call_args_list
+            )
+        )
 
     def assertPathsEqual(
         self, src_path: Path | S3Path, dst_path: Path | S3Path, expected_num_files: int

--- a/test/aibs_informatics_aws_utils/test_s3.py
+++ b/test/aibs_informatics_aws_utils/test_s3.py
@@ -320,9 +320,7 @@ class S3Tests(AwsBaseTest):
         self.assertListEqual(list_s3_paths(sub_prefix, include=pattern), [])
 
         # Passing the original root back in restores the intended behavior.
-        self.assertListEqual(
-            list_s3_paths(sub_prefix, include=pattern, filter_root=root), [bam]
-        )
+        self.assertListEqual(list_s3_paths(sub_prefix, include=pattern, filter_root=root), [bam])
 
     def test__is_folder__is_object__is_object_prefix__is_folder_placeholder_object__work(self):
         ## Setup

--- a/test/aibs_informatics_aws_utils/test_s3.py
+++ b/test/aibs_informatics_aws_utils/test_s3.py
@@ -200,11 +200,14 @@ class S3Tests(AwsBaseTest):
 
     def test__list_s3_paths__all_cases(self):
         ## Setup
-        s3_path = self.get_s3_path("path/to/object")
+        # Patterns are matched against the key relative to the listing root, so the
+        # root is a folder prefix here and the relative keys are `object_a`,
+        # `object-b` and `object/a`.
+        s3_path = self.get_s3_path("path/to/")
         s3_path_a = self.get_s3_path("path/to/object_a")
         s3_path_b = self.get_s3_path("path/to/object-b")
         s3_path_c = self.get_s3_path("path/to/object/a")
-        s3_path_d = self.get_s3_path("path/to/another/object_d")
+        s3_path_d = self.get_s3_path("path/other/object_d")
 
         contents_a = "Hello, it's me"
         contents_b = "I was wondering if after all these years you'd like to meet"
@@ -256,15 +259,70 @@ class S3Tests(AwsBaseTest):
 
         # 3. include provided - match; exclude provided - no match
         s3_paths_all_filters_3 = list_s3_paths(
-            s3_path, include=[re.compile(r"_a")], exclude=missing_patterns
+            s3_path, include=[re.compile(r".*_a")], exclude=missing_patterns
         )
         self.assertListEqual(sorted(s3_paths_all_filters_3), [s3_path_a])
 
         # 4. include provided - match; exclude provided - match
         s3_paths_all_filters_4 = list_s3_paths(
-            s3_path, include=[re.compile(".+")], exclude=[re.compile(r"_a")]
+            s3_path, include=[re.compile(".+")], exclude=[re.compile(r".*_a")]
         )
         self.assertListEqual(sorted(s3_paths_all_filters_4), sorted([s3_path_b, s3_path_c]))
+
+    def test__list_s3_paths__patterns_are_fullmatched(self):
+        """Patterns must describe the whole relative key, not a fragment of it."""
+        s3_path = self.get_s3_path("run1/")
+        bam = self.get_s3_path("run1/sampleA/reads.bam")
+        txt = self.get_s3_path("run1/sampleA/notes.txt")
+        self.put_object(bam.key, "bam")
+        self.put_object(txt.key, "txt")
+
+        # A bare fragment would have matched under the old `.match()` behavior.
+        self.assertListEqual(list_s3_paths(s3_path, include=[re.compile("sampleA")]), [])
+        self.assertListEqual(list_s3_paths(s3_path, include=[re.compile(r".*\.bam")]), [bam])
+        self.assertListEqual(
+            sorted(list_s3_paths(s3_path, include=[re.compile("sampleA/.*")])), sorted([bam, txt])
+        )
+
+    def test__list_s3_paths__accepts_str_patterns(self):
+        """Patterns may be given as plain strings, not just compiled patterns."""
+        s3_path = self.get_s3_path("run1/")
+        bam = self.get_s3_path("run1/reads.bam")
+        txt = self.get_s3_path("run1/notes.txt")
+        self.put_object(bam.key, "bam")
+        self.put_object(txt.key, "txt")
+
+        self.assertListEqual(list_s3_paths(s3_path, include=r".*\.bam"), [bam])
+        self.assertListEqual(list_s3_paths(s3_path, exclude=[r".*\.bam"]), [txt])
+
+    def test__list_s3_paths__explicit_filter_root_anchors_patterns(self):
+        """Listing a sub-prefix keeps working when the original root is passed.
+
+        This is the prepare/batch split: a sync of `run1/` fans out into
+        sub-requests rooted at `run1/sampleA/`, and each sub-request re-lists from
+        its own root. Without an explicit anchor, patterns written against `run1/`
+        stop matching entirely.
+        """
+        root = self.get_s3_path("run1/")
+        sub_prefix = self.get_s3_path("run1/sampleA/")
+        bam = self.get_s3_path("run1/sampleA/reads.bam")
+        txt = self.get_s3_path("run1/sampleA/notes.txt")
+        self.put_object(bam.key, "bam")
+        self.put_object(txt.key, "txt")
+
+        pattern = [re.compile(r"sampleA/.*\.bam")]
+
+        # Written against the original root, the pattern matches when listing it.
+        self.assertListEqual(list_s3_paths(root, include=pattern), [bam])
+
+        # Listing the sub-prefix without an anchor, relative keys are now
+        # `reads.bam` / `notes.txt` and the pattern matches nothing.
+        self.assertListEqual(list_s3_paths(sub_prefix, include=pattern), [])
+
+        # Passing the original root back in restores the intended behavior.
+        self.assertListEqual(
+            list_s3_paths(sub_prefix, include=pattern, filter_root=root), [bam]
+        )
 
     def test__is_folder__is_object__is_object_prefix__is_folder_placeholder_object__work(self):
         ## Setup

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ release = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aibs-informatics-core", specifier = ">=1.0.1,<2" },
+    { name = "aibs-informatics-core", git = "https://github.com/AllenInstitute/aibs-informatics-core.git?branch=feature%2FOCSDV-453-demand-execution-filters" },
     { name = "boto3", specifier = "~=1.35" },
     { name = "tenacity", specifier = "~=9.0" },
 ]
@@ -116,8 +116,8 @@ release = [
 
 [[package]]
 name = "aibs-informatics-core"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
+version = "1.0.6"
+source = { git = "https://github.com/AllenInstitute/aibs-informatics-core.git?branch=feature%2FOCSDV-453-demand-execution-filters#d621cd20deaeb5fea6e5f09f7ff5d434293a2e11" }
 dependencies = [
     { name = "pathlib-abc" },
     { name = "pydantic" },
@@ -126,11 +126,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "stringcase" },
+    { name = "typing-extensions" },
     { name = "typing-inspect" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/67/50502d4e175a65b77e911b0556c95b971758de26a14bc14f16bf6dd8a72f/aibs_informatics_core-1.0.1.tar.gz", hash = "sha256:162055cff5866a96b8ca39f6d6afc28fcdd29ccdf45e256924b76cc920a54db3", size = 73051, upload-time = "2026-03-18T23:15:52.902Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/95/a0e929feabeb3d5d3da8f7c615db8fa591da058bc85ec979e6491739ed3a/aibs_informatics_core-1.0.1-py3-none-any.whl", hash = "sha256:f475e946f14bf50695e340db7555ebb1abe9fa269a16e52644c091d3a01ef1e3", size = 91583, upload-time = "2026-03-18T23:15:51.393Z" },
 ]
 
 [[package]]
@@ -1029,6 +1026,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
## OCSDV-452 — PR-C (aibs-informatics-aws-utils, Release R2)

[OCSDV-452](https://alleninstitute.atlassian.net/browse/OCSDV-452)

Makes the sync layer honor include/exclude filters, anchored to an explicit filter root.

Depends on **aibs-informatics-core R1 (PR-A)** for `DataSyncFilterConfig`, `DataSyncTask.filter_config` / `.filter_root`, `DataSyncConfig.delete`, and the shared `utils.filters` helper.

### ⚠️ Blocked on core R1 — one commit must be dropped before merge

R1 is not published yet, so the first commit (`5a8b97a`) resolves core from the branch carrying it via `[tool.uv.sources]` so CI can run. `tool.uv.sources` is uv-only metadata — setuptools ignores it, so the published wheel still carries the plain `aibs-informatics-core>=...,<2` requirement.

**Before merge, once R1 publishes:** revert `5a8b97a`, raise the version floor in `pyproject.toml` to the R1 version in its place, and re-run `uv lock`. The current bound `>=1.0.1,<2` would otherwise resolve an older core lacking `DataSyncFilterConfig` and fail at import time inside a Batch job.

### One filtering contract, three call sites

Per design decision 1, everything routes through the shared helper in core: regexes matched with `re.fullmatch` against the path **relative to the filter root**, exclude winning over include, empty include including everything.

**`s3.py`**
- `list_s3_paths` — `fullmatch` instead of `match`, and an explicit `filter_root` anchor instead of always stripping `s3_path.key`.
- `sync_paths` — accepts `filter_root` and applies the shared helper on **both** the S3 branch and the local `find_paths` branch, so a pattern behaves identically either side. A source that is itself an object is now filtered rather than unconditionally included.
- `include`/`exclude` widened to core's `Patterns` (`str | Pattern | sequence`), so callers no longer have to pre-compile.

**`data_sync/file_system.py`**
- `refresh` / `from_path` / `get_file_system` accept `filter_config` + `filter_root`.
- `S3FileSystem.refresh` filters **in-loop** over `bucket.objects.filter(...)`, keeping the single streaming pass over prefixes that run to millions of objects.
- `LocalFileSystem.refresh` routes `find_all_paths` through the shared helper.
- `EFSFileSystem` translates an EFS `filter_root` to its local mount path, so a root expressed as an EFS path still anchors correctly against local paths.
- New `total_objects_seen` counter, counted **pre-filter**, for PR-D's zero-match check — the tree only holds kept objects, so this is the only way to tell an empty source apart from filters that matched nothing.

**`data_sync/operations.py`**
- `filter_config` / `filter_root` threaded through `sync`, `sync_task`, `sync_s3_to_local`, `sync_s3_to_s3`, `sync_local_to_s3`.
- `delete` now comes from config instead of being hardcoded `True` at three call sites.
- `sync_local_to_local`: TODO + `logger.warning`. Filtered local→local is deliberately not implemented (design decision 6) — it uses `copy_path`/`move_path`, which take no patterns — so the gap surfaces in job logs rather than as a silently complete full copy.
- `sync_data()` gains `filter_config`, `filter_root`, `delete`.

### Bug fixed

`include_detailed_response` for local→S3 computed `files_transferred` from `find_all_paths(source_path)` and `bytes_transferred` from `get_path_size_bytes(source_path)` — both over the **unfiltered** source. A sync that moved 1 file / 5 bytes reported 2 files / 20 bytes. Both now count over the filtered set; pinned by test.

### Behavior change worth a close look

`list_s3_paths` previously stripped `s3_path.key` as a raw string prefix; it now relativizes on directory boundaries, per the shared contract. For a **folder-suffixed** root (which is what `sync_paths` and all production callers use) the two are identical. They differ only for a non-folder prefix root — listing `s3://b/path/to/object` no longer yields relative key `_a` for `…/object_a`. `test__list_s3_paths__all_cases` was rerooted at a folder prefix accordingly.

### Tests

Extends the existing moto-backed suites.

- Filtered **S3→local**, **local→S3**, **S3→S3**, each also covering the `filter_root` anchor.
- **`FileSystem.partition()` sizes reflect KEPT bytes, not total** (Local and S3) — the property the entire distributed speedup depends on. Binning unfiltered sizes would size every batch job for the full prefix and run them ~95% empty.
- `total_objects_seen` counts pre-filter; zero matches is distinguishable from an empty source.
- `delete=False` retains unmatched destination files; `delete=True` mirrors and therefore removes them — the documented hazard from design decision 3, pinned as behavior rather than left implicit.
- Filtered local→local warns and copies everything.
- `list_s3_paths` fullmatch semantics, `str` patterns, explicit `filter_root`.

`make format && make lint && make test` all pass locally — 547 passed, 1 xfailed (a pre-existing macOS-only xfail).

### Not in this PR

- Prepare handler wiring, `filter_root` on emitted sub-requests, and the zero-match check — PR-D.
- The `PrepareBatchDataSyncResponse` round-trip test from the DoD — that model lives in aws-lambda, so it belongs to PR-D.
- Demand execution wiring (OCSDV-453) and GCS (OCSDV-454).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OCSDV-452]: https://alleninstitute.atlassian.net/browse/OCSDV-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ